### PR TITLE
Get a geoid GeoTIFF file by Geospatial Information Authority of Japan (via PROJ Datumgrid CDN)

### DIFF
--- a/.github/workflows/github-pages-deploy.yaml
+++ b/.github/workflows/github-pages-deploy.yaml
@@ -36,6 +36,10 @@ jobs:
         with:
           node-version: 16
           cache: 'npm'
+      - name: Get a geoid GeoTIFF file by Geospatial Information Authority of Japan (via PROJ Datumgrid CDN)
+        run: |
+          wget https://cdn.proj.org/jp_gsi_gsigeo2011.tif
+          mv jp_gsi_gsigeo2011.tif ./public/proj
       - name: Install dependencies
         run: npm install
       - name: Build


### PR DESCRIPTION
- [PROJ Datumgrid CDN](https://cdn.proj.org/)
- [ジオイド・モデルの提供｜基盤地図情報ダウンロードサービス](https://fgd.gsi.go.jp/download/geoid.php)
- 参考: [国土地理院コンテンツ利用規約 | 国土地理院](https://www.gsi.go.jp/kikakuchousei/kikakuchousei40182.html)